### PR TITLE
Changes to support redirecting .cc logs of postgres backend to a yb-tserver.*

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -330,6 +330,9 @@ typedef unsigned __int64 uint64;
   using fLS::FLAGS_##name
 #endif
 
+// Set whether to log header message to the log file
+DECLARE_bool(log_header_message);
+
 // Set whether appending a timestamp to the log file name
 DECLARE_bool(timestamp_in_logfile_name);
 

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -940,28 +940,6 @@ bool LogFileObject::CreateLogfile(const string& time_pid_string) {
 #ifdef HAVE_FCNTL
   // Mark the file close-on-exec. We don't really care if this fails
   fcntl(fd, F_SETFD, FD_CLOEXEC);
-
-  // Mark the file as exclusive write access to avoid two clients logging to the
-  // same file. This applies particularly when !FLAGS_timestamp_in_logfile_name
-  // (otherwise open would fail because the O_EXCL flag on similar filename).
-  // locks are released on unlock or close() automatically, only after log is
-  // released.
-  // This will work after a fork as it is not inherited (not stored in the fd).
-  // Lock will not be lost because the file is opened with exclusive lock (write)
-  // and we will never read from it inside the process.
-  // TODO windows implementation of this (as flock is not available on mingw).
-  static struct flock w_lock;
-
-  w_lock.l_type = F_WRLCK;
-  w_lock.l_start = 0;
-  w_lock.l_whence = SEEK_SET;
-  w_lock.l_len = 0;
-
-  int wlock_ret = fcntl(fd, F_SETLK, &w_lock);
-  if (wlock_ret == -1) {
-      close(fd); //as we are failing already, do not check errors here
-      return false;
-  }
 #endif
 
   //fdopen in append mode so if the file exists it will fseek to the end

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1110,24 +1110,24 @@ void LogFileObject::Write(bool force_flush,
       ostringstream file_header_stream;
       file_header_stream.fill('0');
       file_header_stream << "Log file created at: "
-                        << 1900+tm_time.tm_year << '/'
-                        << setw(2) << 1+tm_time.tm_mon << '/'
-                        << setw(2) << tm_time.tm_mday
-                        << ' '
-                        << setw(2) << tm_time.tm_hour << ':'
-                        << setw(2) << tm_time.tm_min << ':'
-                        << setw(2) << tm_time.tm_sec << '\n'
-                        << "Running on machine: "
-                        << LogDestination::hostname() << '\n';
+                         << 1900+tm_time.tm_year << '/'
+                         << setw(2) << 1+tm_time.tm_mon << '/'
+                         << setw(2) << tm_time.tm_mday
+                         << ' '
+                         << setw(2) << tm_time.tm_hour << ':'
+                         << setw(2) << tm_time.tm_min << ':'
+                         << setw(2) << tm_time.tm_sec << '\n'
+                         << "Running on machine: "
+                         << LogDestination::hostname() << '\n';
 
       if(!g_application_fingerprint.empty()) {
         file_header_stream << "Application fingerprint: " << g_application_fingerprint << '\n';
       }
 
       file_header_stream << "Running duration (h:mm:ss): "
-                        << PrettyDuration(static_cast<int>(WallTime_Now() - start_time_)) << '\n'
-                        << "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu "
-                        << "threadid file:line] msg" << '\n';
+                         << PrettyDuration(static_cast<int>(WallTime_Now() - start_time_)) << '\n'
+                         << "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu "
+                         << "threadid file:line] msg" << '\n';
       const string& file_header_string = file_header_stream.str();
 
       const int header_len = file_header_string.size();

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -731,39 +731,6 @@ static void TestBasenameAppendWhenNoTimestamp() {
   DeleteFiles(dest + "*");
 }
 
-static void TestTwoProcessesWrite() {
-// test only implemented for platforms with fork & wait; the actual implementation relies on flock
-#if defined(HAVE_SYS_WAIT_H) && defined(HAVE_UNISTD_H) && defined(HAVE_FCNTL)
-  fprintf(stderr, "==== Test setting log file basename and two processes writing - second should fail\n");
-  const string dest = FLAGS_test_tmpdir + "/logging_test_basename_two_processes_writing";
-  DeleteFiles(dest + "*");
-
-  //make both processes write into the same file (easier test)
-  FLAGS_timestamp_in_logfile_name=false;
-  SetLogDestination(GLOG_INFO, dest.c_str());
-  LOG(INFO) << "message to new base, parent";
-  FlushLogFiles(GLOG_INFO);
-
-  pid_t pid = fork();
-  CHECK_ERR(pid);
-  if (pid == 0) {
-    LOG(INFO) << "message to new base, child - should only appear on STDERR not on the file";
-    ShutdownGoogleLogging(); //for children proc
-    exit(0);
-  } else if (pid > 0) {
-    wait(NULL);
-  }
-  FLAGS_timestamp_in_logfile_name=true;
-
-  CheckFile(dest, "message to new base, parent");
-  CheckFile(dest, "message to new base, child - should only appear on STDERR not on the file", false);
-
-  // Release
-  LogToStderr();
-  DeleteFiles(dest + "*");
-#endif
-}
-
 static void TestSymlink() {
 #ifndef OS_WINDOWS
   fprintf(stderr, "==== Test setting log file symlink\n");

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -108,6 +108,7 @@ static void TestDCHECK();
 static void TestSTREQ();
 static void TestBasename();
 static void TestBasenameAppendWhenNoTimestamp();
+static void TestTwoProcessesWrite();
 static void TestSymlink();
 static void TestExtension();
 static void TestWrapper();
@@ -234,6 +235,7 @@ int main(int argc, char **argv) {
 
   TestBasename();
   TestBasenameAppendWhenNoTimestamp();
+  TestTwoProcessesWrite();
   TestSymlink();
   TestExtension();
   TestWrapper();
@@ -727,6 +729,39 @@ static void TestBasenameAppendWhenNoTimestamp() {
   // Release file handle for the destination file to unlock the file in Windows.
   LogToStderr();
   DeleteFiles(dest + "*");
+}
+
+static void TestTwoProcessesWrite() {
+// test only implemented for platforms with fork & wait; the actual implementation relies on flock
+#if defined(HAVE_SYS_WAIT_H) && defined(HAVE_UNISTD_H) && defined(HAVE_FCNTL)
+  fprintf(stderr, "==== Test setting log file basename and two processes writing - both should work\n");
+  const string dest = FLAGS_test_tmpdir + "/logging_test_basename_two_processes_writing";
+  DeleteFiles(dest + "*");
+
+  //make both processes write into the same file (easier test)
+  FLAGS_timestamp_in_logfile_name=false;
+  SetLogDestination(GLOG_INFO, dest.c_str());
+  LOG(INFO) << "message to new base, parent";
+  FlushLogFiles(GLOG_INFO);
+
+  pid_t pid = fork();
+  CHECK_ERR(pid);
+  if (pid == 0) {
+    LOG(INFO) << "message to new base, child";
+    ShutdownGoogleLogging(); //for children proc
+    exit(0);
+  } else if (pid > 0) {
+    wait(NULL);
+  }
+  FLAGS_timestamp_in_logfile_name=true;
+
+  CheckFile(dest, "message to new base, parent");
+  CheckFile(dest, "message to new base, child");
+
+  // Release
+  LogToStderr();
+  DeleteFiles(dest + "*");
+#endif
 }
 
 static void TestSymlink() {

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -108,7 +108,6 @@ static void TestDCHECK();
 static void TestSTREQ();
 static void TestBasename();
 static void TestBasenameAppendWhenNoTimestamp();
-static void TestTwoProcessesWrite();
 static void TestSymlink();
 static void TestExtension();
 static void TestWrapper();
@@ -235,7 +234,6 @@ int main(int argc, char **argv) {
 
   TestBasename();
   TestBasenameAppendWhenNoTimestamp();
-  TestTwoProcessesWrite();
   TestSymlink();
   TestExtension();
   TestWrapper();


### PR DESCRIPTION
- Removed exclusive lock since it prevents two processes from writing to the same file. Since each ysql shell is a new process, this will interfere with redirecting all .cc logs to the tserver file. 
- Modified associated test to verify that both processes write. 
- Added a new flag `log_header_message` which controls whether the log header message is logged. Since we are appending to an existing file, adding this flag removes 4 unneeded log lines everytime a ysql shell is opened, or the cluster is started.