### PR TITLE
Allow updating vmodule levels after vmodule level has been cached

### DIFF
--- a/src/glog/vlog_is_on.h.in
+++ b/src/glog/vlog_is_on.h.in
@@ -81,10 +81,10 @@
 // parsing of --vmodule flag and/or SetVLOGLevel calls.
 #define VLOG_IS_ON(verboselevel)                                \
   __extension__  \
-  ({ static @ac_google_namespace@::int32* vlocal__ = NULL;           \
+  ({ static @ac_google_namespace@::SiteFlag vlocal__{NULL, NULL, 0, NULL};       \
      @ac_google_namespace@::int32 verbose_level__ = (verboselevel);                    \
-     (vlocal__ == NULL ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
-                        __FILE__, verbose_level__) : *vlocal__ >= verbose_level__); \
+     (vlocal__.level == NULL ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
+                        __FILE__, verbose_level__) : *vlocal__.level >= verbose_level__); \
   })
 #else
 // GNU extensions not available, so we do not support --vmodule.
@@ -105,6 +105,13 @@ extern GOOGLE_GLOG_DLL_DECL int SetVLOGLevel(const char* module_pattern,
 
 // Various declarations needed for VLOG_IS_ON above: =========================
 
+struct SiteFlag {
+  @ac_google_namespace@::int32* level;
+  const char* base_name;
+  size_t base_len;
+  SiteFlag* next;
+};
+
 // Helper routine which determines the logging info for a particalur VLOG site.
 //   site_flag     is the address of the site-local pointer to the controlling
 //                 verbosity level
@@ -114,7 +121,7 @@ extern GOOGLE_GLOG_DLL_DECL int SetVLOGLevel(const char* module_pattern,
 // We will return the return value for VLOG_IS_ON
 // and if possible set *site_flag appropriately.
 extern GOOGLE_GLOG_DLL_DECL bool InitVLOG3__(
-    @ac_google_namespace@::int32** site_flag,
+    @ac_google_namespace@::SiteFlag* site_flag,
     @ac_google_namespace@::int32* site_default,
     const char* fname,
     @ac_google_namespace@::int32 verbose_level);

--- a/src/glog/vlog_is_on.h.in
+++ b/src/glog/vlog_is_on.h.in
@@ -81,12 +81,11 @@
 // parsing of --vmodule flag and/or SetVLOGLevel calls.
 #define VLOG_IS_ON(verboselevel)                                \
   __extension__  \
-  ({ static @ac_google_namespace@::int32* vlocal__ = &@ac_google_namespace@::kLogSiteUninitialized;           \
+  ({ static @ac_google_namespace@::int32* vlocal__ = NULL;           \
      @ac_google_namespace@::int32 verbose_level__ = (verboselevel);                    \
-     (*vlocal__ >= verbose_level__) &&                          \
-     ((vlocal__ != &@ac_google_namespace@::kLogSiteUninitialized) ||                   \
-      (@ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v,                         \
-                   __FILE__, verbose_level__))); })
+     (vlocal__ == NULL ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
+                        __FILE__, verbose_level__) : *vlocal__ >= verbose_level__); \
+  })
 #else
 // GNU extensions not available, so we do not support --vmodule.
 // Dynamic value of FLAGS_v always controls the logging level.
@@ -105,12 +104,6 @@ extern GOOGLE_GLOG_DLL_DECL int SetVLOGLevel(const char* module_pattern,
                                              int log_level);
 
 // Various declarations needed for VLOG_IS_ON above: =========================
-
-// Special value used to indicate that a VLOG_IS_ON site has not been
-// initialized.  We make this a large value, so the common-case check
-// of "*vlocal__ >= verbose_level__" in VLOG_IS_ON definition
-// passes in such cases and InitVLOG3__ is then triggered.
-extern @ac_google_namespace@::int32 kLogSiteUninitialized;
 
 // Helper routine which determines the logging info for a particalur VLOG site.
 //   site_flag     is the address of the site-local pointer to the controlling

--- a/src/logging_unittest.cc
+++ b/src/logging_unittest.cc
@@ -95,6 +95,7 @@ static void TestLogging(bool check_counts);
 static void TestRawLogging();
 static void LogWithLevels(int v, int severity, bool err, bool alsoerr);
 static void TestLoggingLevels();
+static void TestVLogModule();
 static void TestLogString();
 static void TestLogSink();
 static void TestLogToString();
@@ -212,6 +213,7 @@ int main(int argc, char **argv) {
   TestLogging(true);
   TestRawLogging();
   TestLoggingLevels();
+  TestVLogModule();
   TestLogString();
   TestLogSink();
   TestLogToString();
@@ -439,6 +441,24 @@ void TestLoggingLevels() {
   LogWithLevels(0, GLOG_FATAL, false, true);
   LogWithLevels(1, GLOG_WARNING, false, false);
   LogWithLevels(1, GLOG_FATAL, false, true);
+}
+
+int TestVlogHelper() {
+  if (VLOG_IS_ON(1)) {
+    return 1;
+  }
+  return 0;
+}
+
+void TestVLogModule() {
+  int c = TestVlogHelper();
+  EXPECT_EQ(0, c);
+
+#if defined(__GNUC__)
+  EXPECT_EQ(0, SetVLOGLevel("logging_unittest", 1));
+  c = TestVlogHelper();
+  EXPECT_EQ(1, c);
+#endif
 }
 
 TEST(DeathRawCHECK, logging) {

--- a/src/vlog_is_on.cc
+++ b/src/vlog_is_on.cc
@@ -105,8 +105,6 @@ GOOGLE_GLOG_DLL_DECL bool SafeFNMatch_(const char* pattern,
 
 using glog_internal_namespace_::SafeFNMatch_;
 
-int32 kLogSiteUninitialized = 1000;
-
 // List of per-module log levels from FLAGS_vmodule.
 // Once created each element is never deleted/modified
 // except for the vlog_level: other threads will read VModuleInfo blobs

--- a/src/windows/glog/vlog_is_on.h
+++ b/src/windows/glog/vlog_is_on.h
@@ -85,12 +85,11 @@
 // parsing of --vmodule flag and/or SetVLOGLevel calls.
 #define VLOG_IS_ON(verboselevel)                                \
   __extension__  \
-  ({ static google::int32* vlocal__ = &google::kLogSiteUninitialized;           \
+  ({ static @ac_google_namespace@::int32* vlocal__ = NULL;           \
      google::int32 verbose_level__ = (verboselevel);                    \
-     (*vlocal__ >= verbose_level__) &&                          \
-     ((vlocal__ != &google::kLogSiteUninitialized) ||                   \
-      (google::InitVLOG3__(&vlocal__, &FLAGS_v,                         \
-                   __FILE__, verbose_level__))); })
+     (vlocal__ == NULL ? @ac_google_namespace@::InitVLOG3__(&vlocal__, &FLAGS_v, \
+                        __FILE__, verbose_level__) : *vlocal__ >= verbose_level__); \
+  })
 #else
 // GNU extensions not available, so we do not support --vmodule.
 // Dynamic value of FLAGS_v always controls the logging level.
@@ -109,12 +108,6 @@ extern GOOGLE_GLOG_DLL_DECL int SetVLOGLevel(const char* module_pattern,
                                              int log_level);
 
 // Various declarations needed for VLOG_IS_ON above: =========================
-
-// Special value used to indicate that a VLOG_IS_ON site has not been
-// initialized.  We make this a large value, so the common-case check
-// of "*vlocal__ >= verbose_level__" in VLOG_IS_ON definition
-// passes in such cases and InitVLOG3__ is then triggered.
-extern google::int32 kLogSiteUninitialized;
 
 // Helper routine which determines the logging info for a particalur VLOG site.
 //   site_flag     is the address of the site-local pointer to the controlling


### PR DESCRIPTION
Cherry pick the following commits to get dynamic update of vmodules even after it has been cached

[Use NULL to indicate uninitialized VLOG_IS_ON site.](https://github.com/google/glog/commit/4a82a856d281e78c2af8c0ea35f0b6b8b4688598)
[Allow updating vmodule levels after vmodule level has been cached #650](https://github.com/google/glog/commit/86fea1ab254c463cbb72e5ce8bcc6855bc4e1e9c)