### PR TITLE
Add an optional prefix message to every log message

### DIFF
--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1528,6 +1528,8 @@ GOOGLE_GLOG_DLL_DECL void TruncateStdoutStderr();
 // Thread-safe.
 GOOGLE_GLOG_DLL_DECL const char* GetLogSeverityName(LogSeverity severity);
 
+GOOGLE_GLOG_DLL_DECL void SetLogPrefix(const char*(*prefix_func)()));
+
 // ---------------------------------------------------------------------
 // Implementation details that are not useful to most clients
 // ---------------------------------------------------------------------

--- a/src/glog/logging.h.in
+++ b/src/glog/logging.h.in
@@ -1528,7 +1528,7 @@ GOOGLE_GLOG_DLL_DECL void TruncateStdoutStderr();
 // Thread-safe.
 GOOGLE_GLOG_DLL_DECL const char* GetLogSeverityName(LogSeverity severity);
 
-GOOGLE_GLOG_DLL_DECL void SetLogPrefix(const char*(*prefix_func)()));
+GOOGLE_GLOG_DLL_DECL void SetLogPrefix(const char*(*prefix_func)());
 
 // ---------------------------------------------------------------------
 // Implementation details that are not useful to most clients

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -388,7 +388,10 @@ const char* GetLogSeverityName(LogSeverity severity) {
   return LogSeverityNames[severity];
 }
 
-const char* EmptyPrefixLog() { return ""; }
+const char* EmptyPrefixLog() {
+  const static char c = '\0';
+  return &c;
+}
 
 const char* (*log_prefix_func)() = &EmptyPrefixLog;
 
@@ -1323,7 +1326,7 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    stream() << LogSeverityNames[severity][0] << setw(2)
+    stream() << log_prefix_func() << LogSeverityNames[severity][0] << setw(2)
              << 1 + data_->tm_time_.tm_mon << setw(2) << data_->tm_time_.tm_mday << ' ' << setw(2)
              << data_->tm_time_.tm_hour << ':' << setw(2) << data_->tm_time_.tm_min << ':'
              << setw(2) << data_->tm_time_.tm_sec << "." << setw(6) << usecs << ' ' << setfill(' ')

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -388,6 +388,14 @@ const char* GetLogSeverityName(LogSeverity severity) {
   return LogSeverityNames[severity];
 }
 
+const char* EmptyPrefixLog() { return ""; }
+
+const char* (*log_prefix_func)() = &EmptyPrefixLog;
+
+GOOGLE_GLOG_DLL_DECL void SetLogPrefix(const char* (*prefix_func)()) {
+  log_prefix_func = prefix_func;
+}
+
 static bool SendEmailInternal(const char*dest, const char *subject,
                               const char*body, bool use_logging);
 
@@ -1315,16 +1323,11 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    stream() << LogSeverityNames[severity][0]
-             << setw(2) << 1+data_->tm_time_.tm_mon
-             << setw(2) << data_->tm_time_.tm_mday
-             << ' '
-             << setw(2) << data_->tm_time_.tm_hour  << ':'
-             << setw(2) << data_->tm_time_.tm_min   << ':'
-             << setw(2) << data_->tm_time_.tm_sec   << "."
-             << setw(6) << usecs
-             << ' '
-             << setfill(' ') << setw(5);
+    stream() << LogSeverityNames[severity][0] << setw(2)
+             << 1 + data_->tm_time_.tm_mon << setw(2) << data_->tm_time_.tm_mday << ' ' << setw(2)
+             << data_->tm_time_.tm_hour << ':' << setw(2) << data_->tm_time_.tm_min << ':'
+             << setw(2) << data_->tm_time_.tm_sec << "." << setw(6) << usecs << ' ' << setfill(' ')
+             << setw(5);
     if (FLAGS_log_prefix_include_pid) {
       stream() << static_cast<unsigned int>(getpid()) << setfill('0') << ' ';
     }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1323,12 +1323,12 @@ void LogMessage::Init(const char* file,
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
     stream() << (log_prefix_func ? log_prefix_func() : '')
              << LogSeverityNames[severity][0]
-             << setw(2) << 1 + data_->tm_time_.tm_mon
+             << setw(2) << 1+data_->tm_time_.tm_mon
              << setw(2) << data_->tm_time_.tm_mday
              << ' '
-             << setw(2) << data_->tm_time_.tm_hour << ':'
-             << setw(2) << data_->tm_time_.tm_min << ':'
-             << setw(2) << data_->tm_time_.tm_sec << "."
+             << setw(2) << data_->tm_time_.tm_hour  << ':'
+             << setw(2) << data_->tm_time_.tm_min   << ':'
+             << setw(2) << data_->tm_time_.tm_sec   << "."
              << setw(6) << usecs
              << ' '
              << setfill(' ') << setw(5);

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1321,10 +1321,16 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    stream() << (log_prefix_func ? log_prefix_func() : '') << LogSeverityNames[severity][0]
-             << setw(2) << 1 + data_->tm_time_.tm_mon << setw(2) << data_->tm_time_.tm_mday << ' '
-             << setw(2) << data_->tm_time_.tm_hour << ':' << setw(2) << data_->tm_time_.tm_min
-             << ':' << setw(2) << data_->tm_time_.tm_sec << "." << setw(6) << usecs << ' '
+    stream() << (log_prefix_func ? log_prefix_func() : '')
+             << LogSeverityNames[severity][0]
+             << setw(2) << 1 + data_->tm_time_.tm_mon
+             << setw(2) << data_->tm_time_.tm_mday
+             << ' '
+             << setw(2) << data_->tm_time_.tm_hour << ':'
+             << setw(2) << data_->tm_time_.tm_min << ':'
+             << setw(2) << data_->tm_time_.tm_sec << "."
+             << setw(6) << usecs
+             << ' '
              << setfill(' ') << setw(5);
     if (FLAGS_log_prefix_include_pid) {
       stream() << static_cast<unsigned int>(getpid()) << setfill('0') << ' ';

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -388,12 +388,7 @@ const char* GetLogSeverityName(LogSeverity severity) {
   return LogSeverityNames[severity];
 }
 
-const char* EmptyPrefixLog() {
-  const static char c = '\0';
-  return &c;
-}
-
-const char* (*log_prefix_func)() = &EmptyPrefixLog;
+static const char* (*log_prefix_func)() = nullptr;
 
 GOOGLE_GLOG_DLL_DECL void SetLogPrefix(const char* (*prefix_func)()) {
   log_prefix_func = prefix_func;
@@ -1326,11 +1321,11 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    stream() << log_prefix_func() << LogSeverityNames[severity][0] << setw(2)
-             << 1 + data_->tm_time_.tm_mon << setw(2) << data_->tm_time_.tm_mday << ' ' << setw(2)
-             << data_->tm_time_.tm_hour << ':' << setw(2) << data_->tm_time_.tm_min << ':'
-             << setw(2) << data_->tm_time_.tm_sec << "." << setw(6) << usecs << ' ' << setfill(' ')
-             << setw(5);
+    stream() << (log_prefix_func ? log_prefix_func() : '') << LogSeverityNames[severity][0]
+             << setw(2) << 1 + data_->tm_time_.tm_mon << setw(2) << data_->tm_time_.tm_mday << ' '
+             << setw(2) << data_->tm_time_.tm_hour << ':' << setw(2) << data_->tm_time_.tm_min
+             << ':' << setw(2) << data_->tm_time_.tm_sec << "." << setw(6) << usecs << ' '
+             << setfill(' ') << setw(5);
     if (FLAGS_log_prefix_include_pid) {
       stream() << static_cast<unsigned int>(getpid()) << setfill('0') << ' ';
     }

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1323,7 +1323,7 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    stream() << LogSeverityNames[severity][0] << setw(2)
+    stream() << log_prefix_func() << LogSeverityNames[severity][0] << setw(2)
              << 1 + data_->tm_time_.tm_mon << setw(2) << data_->tm_time_.tm_mday << ' ' << setw(2)
              << data_->tm_time_.tm_hour << ':' << setw(2) << data_->tm_time_.tm_min << ':'
              << setw(2) << data_->tm_time_.tm_sec << "." << setw(6) << usecs << ' ' << setfill(' ')

--- a/src/logging.cc
+++ b/src/logging.cc
@@ -1321,7 +1321,7 @@ void LogMessage::Init(const char* file,
   //    (log level, GMT month, date, time, thread_id, file basename, line)
   // We exclude the thread_id for the default thread.
   if (FLAGS_log_prefix && (line != kNoLogPrefix)) {
-    stream() << (log_prefix_func ? log_prefix_func() : '')
+    stream() << (log_prefix_func ? log_prefix_func() : "")
              << LogSeverityNames[severity][0]
              << setw(2) << 1+data_->tm_time_.tm_mon
              << setw(2) << data_->tm_time_.tm_mday

--- a/src/windows/glog/logging.h
+++ b/src/windows/glog/logging.h
@@ -1530,6 +1530,8 @@ GOOGLE_GLOG_DLL_DECL void TruncateStdoutStderr();
 // Thread-safe.
 GOOGLE_GLOG_DLL_DECL const char* GetLogSeverityName(LogSeverity severity);
 
+GOOGLE_GLOG_DLL_DECL void SetLogPrefix(const char*(*prefix_func)());
+
 // ---------------------------------------------------------------------
 // Implementation details that are not useful to most clients
 // ---------------------------------------------------------------------


### PR DESCRIPTION
Introducing log_prefix_func which generates a character string to be used as the prefix of every log message.
SetLogPrefix is used to set this prefix function.

SetLogPrefix will be set to a function that returns a thread local string that identifies its process\service name. This is useful in yb MiniCluster tests which starts several master and tserver services on a single test process. Each thread will store its respective service names in a thread local string that we return via the prefix function.

In xCluster tests where we have two clusters with identical master and tservers we will print a more detailed name [ClusterName serviceName-serviceId] as a prefix.