### PR TITLE
Ensure we use the backtrace function regardless of the OS

### DIFF
--- a/src/utilities.h
+++ b/src/utilities.h
@@ -123,13 +123,13 @@
 
 #if !defined(STACKTRACE_H) && defined(HAVE_EXECINFO_H)
 # define STACKTRACE_H "stacktrace_generic-inl.h"
-# define YB_USING_STRACKTRACE_GENERIC_H 1
+# define YB_USING_STRACKTRACE_GENERIC_H
 #endif
 
-#if defined(__linux__) && !YB_USING_STRACKTRACE_GENERIC_H
-#error "YugabyteDB requirement: we should always use glibc stack unwinder on Linux"
-#undef YB_USING_STRACKTRACE_GENERIC_H
+#ifndef YB_USING_STRACKTRACE_GENERIC_H
+#error "YugabyteDB requirement: we should always use stack unwinder based on the backtrace function"
 #endif
+#undef YB_USING_STRACKTRACE_GENERIC_H
 
 #if defined(STACKTRACE_H)
 # define HAVE_STACKTRACE


### PR DESCRIPTION
A follow-up for e06a7bb38a82a630e5267f1f9d74c5eb2ab6c43d. We should be using the backtrace function on macOS as well, not only on Linux.